### PR TITLE
Tweak end-user strings

### DIFF
--- a/src/steps/email-count-equals.ts
+++ b/src/steps/email-count-equals.ts
@@ -6,7 +6,7 @@ import { Inbox } from '../models';
 /*tslint:disable:no-else-after-return*/
 export class EmailCountEqualsStep extends BaseStep implements StepInterface {
 
-  protected stepName: string = 'Check the email count on a Mailgun Inbox';
+  protected stepName: string = 'Check the number of emails received';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'there should be (?<count>\\d+) emails in mailgun for (?<email>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
@@ -17,7 +17,7 @@ export class EmailCountEqualsStep extends BaseStep implements StepInterface {
   }, {
     field: 'count',
     type: FieldDefinition.Type.NUMERIC,
-    description: 'The email count',
+    description: 'The number received',
   }];
 
   async executeStep(step: Step) {

--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -7,7 +7,7 @@ import { Email, Inbox } from '../models';
 export class EmailFieldValidationStep extends BaseStep implements StepInterface {
   private operators: string[] = ['should contain', 'should not contain', 'should be'];
 
-  protected stepName: string = 'Check a field on a Mailgun Email';
+  protected stepName: string = 'Check the content of an email';
   // tslint:disable-next-line:max-line-length
   protected stepExpression: string = 'the (?<field>(subject|body-html|body-plain|from)) of the (?<position>\\d+)(?:(st|nd|rd|th))? mailgun email for (?<email>.+) (?<operator>(should contain|should not contain|should be)) (?<expectation>.+)';
   protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
@@ -16,21 +16,21 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
     type: FieldDefinition.Type.EMAIL,
     description: 'The inbox\'s email address',
   }, {
-    field: 'field',
-    type: FieldDefinition.Type.STRING,
-    description: 'Field name to check',
-  }, {
-    field: 'expectation',
-    type: FieldDefinition.Type.ANYSCALAR,
-    description: 'Expected field value',
-  }, {
     field: 'position',
     type: FieldDefinition.Type.NUMERIC,
     description: 'The nth message to check from the email\'s inbox',
   }, {
+    field: 'field',
+    type: FieldDefinition.Type.STRING,
+    description: 'Field name to check',
+  }, {
     field: 'operator',
     type: FieldDefinition.Type.STRING,
     description: 'The operator to use when performing the validation. Current supported values are: should contain, should not contain, and should be',
+  }, {
+    field: 'expectation',
+    type: FieldDefinition.Type.ANYSCALAR,
+    description: 'Expected field value',
   }];
 
   async executeStep(step: Step) {

--- a/test/steps/email-count-equals.ts
+++ b/test/steps/email-count-equals.ts
@@ -48,7 +48,7 @@ describe('EmailCountEqualsStep', () => {
     it('should return expected step metadata', () => {
       const def: StepDefinition = stepUnderTest.getDefinition();
       expect(def.getStepId()).to.equal('EmailCountEqualsStep');
-      expect(def.getName()).to.equal('Check the email count on a Mailgun Inbox');
+      expect(def.getName()).to.equal('Check the number of emails received');
       expect(def.getExpression()).to.equal('there should be (?<count>\\d+) emails in mailgun for (?<email>.+)');
       expect(def.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });

--- a/test/steps/email-field-validation.ts
+++ b/test/steps/email-field-validation.ts
@@ -42,31 +42,31 @@ describe('EmailFieldValidationStep', () => {
       expect(fields[0].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
       expect(fields[0].type).to.equal(FieldDefinition.Type.EMAIL);
 
-      // Field Name field
-      expect(fields[1].key).to.equal('field');
-      expect(fields[1].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
-      expect(fields[1].type).to.equal(FieldDefinition.Type.STRING);
-
-      // Expectation field
-      expect(fields[2].key).to.equal('expectation');
-      expect(fields[2].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
-      expect(fields[2].type).to.equal(FieldDefinition.Type.ANYSCALAR);
-
       // Position field
-      expect(fields[3].key).to.equal('position');
-      expect(fields[3].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
-      expect(fields[3].type).to.equal(FieldDefinition.Type.NUMERIC);
+      expect(fields[1].key).to.equal('position');
+      expect(fields[1].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+      expect(fields[1].type).to.equal(FieldDefinition.Type.NUMERIC);
+
+      // Field Name field
+      expect(fields[2].key).to.equal('field');
+      expect(fields[2].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+      expect(fields[2].type).to.equal(FieldDefinition.Type.STRING);
 
       // Operator field
-      expect(fields[4].key).to.equal('operator');
+      expect(fields[3].key).to.equal('operator');
+      expect(fields[3].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
+      expect(fields[3].type).to.equal(FieldDefinition.Type.STRING);
+
+      // Expectation field
+      expect(fields[4].key).to.equal('expectation');
       expect(fields[4].optionality).to.equal(FieldDefinition.Optionality.REQUIRED);
-      expect(fields[4].type).to.equal(FieldDefinition.Type.STRING);
+      expect(fields[4].type).to.equal(FieldDefinition.Type.ANYSCALAR);
     });
 
     it('should return expected step metadata', () => {
       const stepDef: StepDefinition = stepUnderTest.getDefinition();
       expect(stepDef.getStepId()).to.equal('EmailFieldValidationStep');
-      expect(stepDef.getName()).to.equal('Check a field on a Mailgun Email');
+      expect(stepDef.getName()).to.equal('Check the content of an email');
       expect(stepDef.getExpression()).to.equal('the (?<field>(subject|body-html|body-plain|from)) of the (?<position>\\d+)(?:(st|nd|rd|th))? mailgun email for (?<email>.+) (?<operator>(should contain|should not contain|should be)) (?<expectation>.+)');
       expect(stepDef.getType()).to.equal(StepDefinition.Type.VALIDATION);
     });


### PR DESCRIPTION
Minor simplifications to step naming and step field ordering.