### PR TITLE
Position parameter parsing fixes

### DIFF
--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -37,7 +37,7 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
     const stepData: any = step.getData() ? step.getData().toJavaScript() : {};
     const expectation = stepData.expectation;
     const field = stepData.field;
-    const position = stepData.position || 1;
+    const position = parseInt(stepData.position, 2) || 1;
     const operator = stepData.operator;
 
     try {
@@ -63,6 +63,7 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
         return this.error(inbox['message']);
       }
 
+      console.log('Position', position, position - 1);
       if (!inbox.items[position - 1]) {
         return this.error('Cannot fetch email in position: %s', [
           position,

--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -37,7 +37,8 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
     const stepData: any = step.getData() ? step.getData().toJavaScript() : {};
     const expectation = stepData.expectation;
     const field = stepData.field;
-    const position = parseInt(stepData.position, 2) || 1;
+    // tslint:disable-next-line:radix
+    const position = parseInt(stepData.position) || 1;
     const operator = stepData.operator;
 
     try {
@@ -63,7 +64,6 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
         return this.error(inbox['message']);
       }
 
-      console.log('Position', position, position - 1);
       if (!inbox.items[position - 1]) {
         return this.error('Cannot fetch email in position: %s', [
           position,


### PR DESCRIPTION
# Problem
When the step `email-field-validation` is ran using `crank cog:steps..` it fails to get the email message given a position while if you run the step as scenario/`.yml` it works without problem. What happened was the `position` input is being parsed as e.g. `1st` rather than `1`. To fix this, `parseInt`-ed the `position` input