### PR TITLE
Adds Step for checking Broken Links in Email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -777,9 +777,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -919,6 +919,14 @@
         "jsonfile": "5.0.0",
         "lodash": "4.17.15",
         "semver": "5.6.0"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+          "dev": true
+        }
       }
     },
     "check-error": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1715,6 +1715,15 @@
         "pump": "^3.0.0"
       }
     },
+    "get-urls": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-9.2.0.tgz",
+      "integrity": "sha512-ErGHKhzGIrtobqmNNxjy7yxe4cEmAp9SMerzmFpldn0CkEr2EC+SvIiyef038JDjl2LVng7MMw8YunUKM7k3ww==",
+      "requires": {
+        "normalize-url": "^4.3.0",
+        "url-regex": "^5.0.0"
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -2971,6 +2980,11 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
+    "ip-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -4090,6 +4104,11 @@
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
+    },
+    "normalize-url": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -5253,6 +5272,11 @@
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
     },
+    "tlds": {
+      "version": "1.203.1",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
+      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw=="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5682,6 +5706,15 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-5.0.0.tgz",
+      "integrity": "sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==",
+      "requires": {
+        "ip-regex": "^4.1.0",
+        "tlds": "^1.203.0"
+      }
     },
     "use": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,6 +200,12 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/bluebird": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.28.tgz",
+      "integrity": "sha512-0Vk/kqkukxPKSzP9c8WJgisgGDx5oZDbsLLWIP5t70yThO/YleE+GEm2S1GlRALTaack3O7U5OS5qEm7q2kciA==",
+      "dev": true
+    },
     "@types/bytebuffer": {
       "version": "5.0.40",
       "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
@@ -208,6 +214,12 @@
         "@types/long": "*",
         "@types/node": "*"
       }
+    },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
     },
     "@types/chai": {
       "version": "4.2.1",
@@ -226,15 +238,6 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
-    "@types/mailgun-js": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/@types/mailgun-js/-/mailgun-js-0.22.3.tgz",
-      "integrity": "sha512-d3ME0/dgEkD4/fkXi0rYFd6zsjXGwfKwR+zwegtvI//rxIulyCjFCCHky8RutjHaLkVb+g5HIIacp0vmFKNVLQ==",
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^2.5.0"
-      }
-    },
     "@types/mocha": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
@@ -245,6 +248,41 @@
       "version": "12.7.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
       "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ=="
+    },
+    "@types/request": {
+      "version": "2.48.3",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
+      "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@types/request-promise": {
+      "version": "4.1.44",
+      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.44.tgz",
+      "integrity": "sha512-RId7eFsUKxfal1LirDDIcOp9u3MM3NXFDBcC3sqIMcmu7f4U6DsCEMD8RbLZtnPrQlN5Jc79di/WPsIEDO4keg==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/request": "*"
+      }
     },
     "@types/sinon": {
       "version": "7.0.13",
@@ -260,6 +298,23 @@
       "requires": {
         "@types/chai": "*",
         "@types/sinon": "*"
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-bgblack": {
@@ -638,6 +693,19 @@
         "optjs": "~3.2.2"
       }
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -670,6 +738,16 @@
         "gulp-header": "^1.7.1"
       }
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -690,11 +768,18 @@
         "pascalcase": "^0.1.1"
       }
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
-      "dev": true
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -781,6 +866,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
@@ -969,8 +1059,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cp-file": {
       "version": "6.2.0",
@@ -1019,6 +1108,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "date.js": {
@@ -1185,6 +1282,20 @@
         }
       }
     },
+    "dom-parser": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/dom-parser/-/dom-parser-0.1.6.tgz",
+      "integrity": "sha512-3nVRKbLEwmGfghLoeT1dxlK/0votalnOfasP+8VCHYDfDuCETY4LeMblfOeqww6XZk2ymZ1Uewy/hVad6Dy3yw=="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -1330,6 +1441,11 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -1355,6 +1471,11 @@
         "to-regex": "^3.0.1"
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
     "falsey": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/falsey/-/falsey-0.3.2.tgz",
@@ -1371,6 +1492,16 @@
           "dev": true
         }
       }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1478,10 +1609,15 @@
         }
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
     "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -1576,6 +1712,14 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.4",
@@ -2609,6 +2753,20 @@
         "typeof-article": "^0.1.1"
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2751,6 +2909,16 @@
       "requires": {
         "is-self-closing": "^1.0.1",
         "kind-of": "^6.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https": {
@@ -2993,6 +3161,11 @@
         "has-symbols": "^1.0.0"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3016,6 +3189,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -3126,6 +3304,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -3138,6 +3321,21 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "jsonfile": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
@@ -3146,6 +3344,17 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^0.1.2"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "just-extend": {
@@ -3210,8 +3419,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -4020,6 +4228,11 @@
         }
       }
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -4273,6 +4486,11 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -4317,6 +4535,11 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "psl": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -4326,6 +4549,16 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -4451,6 +4684,52 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "request-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
+      "integrity": "sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4502,8 +4781,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -4513,6 +4791,11 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "self-closing-tags": {
       "version": "1.0.1",
@@ -4806,6 +5089,22 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -4826,6 +5125,11 @@
           }
         }
       }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-width": {
       "version": "1.0.2",
@@ -5075,6 +5379,22 @@
         }
       }
     },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -5227,6 +5547,19 @@
         "tslib": "^1.8.1"
       }
     },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5328,6 +5661,14 @@
         }
       }
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -5349,8 +5690,7 @@
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-      "dev": true
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -5360,6 +5700,16 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "warning-symbol": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/google-protobuf": "^3.2.7",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.4",
+    "@types/request-promise": "^4.1.44",
     "chai": "^4.2.0",
     "check-engine": "^1.8.1",
     "grpc-tools": "^1.7.3",
@@ -55,9 +56,12 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
+    "dom-parser": "^0.1.6",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.21.1",
     "https": "^1.0.0",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.4",
     "ts-node": "^8.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "bluebird": "^3.7.1",
     "dom-parser": "^0.1.6",
+    "get-urls": "^9.2.0",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.21.1",
     "https": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "node": ">= 10.0.0"
   },
   "devDependencies": {
+    "@types/bluebird": "^3.5.28",
     "@types/chai": "^4.1.7",
     "@types/google-protobuf": "^3.2.7",
     "@types/mocha": "^5.2.7",
@@ -56,6 +57,7 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
+    "bluebird": "^3.7.1",
     "dom-parser": "^0.1.6",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.21.1",

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -1,5 +1,6 @@
 import * as grpc from 'grpc';
 import * as https from 'https';
+import * as RequestPromise from 'request-promise';
 import { Field } from '../core/base-step';
 import { FieldDefinition } from '../proto/cog_pb';
 import { Inbox, Email } from '../models';
@@ -26,9 +27,11 @@ export class ClientWrapper {
   private auth: grpc.Metadata;
   private basicAuth: string;
   private client: any;
+  private request: RequestPromise.RequestPromiseAPI;
 
-  constructor(auth: grpc.Metadata, clientConstructor = https) {
+  constructor(auth: grpc.Metadata, clientConstructor = https, request = RequestPromise) {
     this.auth = auth;
+    this.request = request;
     const creds: string = `api:${this.auth.get('apiKey').toString()}`;
     this.basicAuth = `Basic ${Buffer.from(creds).toString('base64')}`;
     this.client = clientConstructor;
@@ -86,5 +89,15 @@ export class ClientWrapper {
     });
 
     return result;
+  }
+
+  public async evaluateUrls(urls: string[]) {
+    console.table(urls);
+    const promises = [];
+    urls.forEach((url) => {
+      promises.push(this.request.get(url));
+    });
+
+    return Promise.all(promises);
   }
 }

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -5,6 +5,8 @@ import { Field } from '../core/base-step';
 import { FieldDefinition } from '../proto/cog_pb';
 import { Inbox, Email } from '../models';
 
+import { Promise as Bluebird } from 'bluebird';
+
 export class ClientWrapper {
   public static expectedAuthFields: Field[] = [{
     field: 'apiKey',
@@ -92,11 +94,20 @@ export class ClientWrapper {
   }
 
   public async evaluateUrls(urls: string[]) {
-    const promises = [];
-    urls.forEach((url) => {
-      promises.push(this.request.get(url));
-    });
+    const brokenUrls = [];
 
-    return Promise.all(promises);
+    return new Promise((resolve) => {
+      Bluebird.each(urls, (url) => {
+        return this.request.get(url).then((res) => {
+        }).catch(() => {
+          brokenUrls.push(url);
+        });
+      }).then(() => {
+        resolve(brokenUrls);
+      }).catch(() => {
+        resolve(brokenUrls);
+      });
+
+    });
   }
 }

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -92,7 +92,6 @@ export class ClientWrapper {
   }
 
   public async evaluateUrls(urls: string[]) {
-    console.table(urls);
     const promises = [];
     urls.forEach((url) => {
       promises.push(this.request.get(url));

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -1,0 +1,86 @@
+import { BaseStep, Field, StepInterface } from '../core/base-step';
+import { FieldDefinition, Step, StepDefinition } from '../proto/cog_pb';
+import { Inbox } from '../models';
+
+import * as DomParser from 'dom-parser';
+import * as RequestPromise from 'request-promise';
+
+/*tslint:disable:no-else-after-return*/
+export class EmailLinksValidationStep extends BaseStep implements StepInterface {
+
+  protected stepName: string = 'Check that no link in an email is broken';
+  // tslint:disable-next-line:max-line-length
+  protected stepExpression: string = 'the (?<position>\\d+)(?:(st|nd|rd|th))? mailgun email for (?<email>.+) should not contain broken links';
+  protected stepType: StepDefinition.Type = StepDefinition.Type.VALIDATION;
+  protected expectedFields: Field[] = [{
+    field: 'email',
+    type: FieldDefinition.Type.EMAIL,
+    description: 'The inbox\'s email address',
+  }, {
+    field: 'position',
+    type: FieldDefinition.Type.NUMERIC,
+    description: 'The nth message to check from the email\'s inbox',
+  }];
+
+  async executeStep(step: Step) {
+    const stepData: any = step.getData() ? step.getData().toJavaScript() : {};
+
+    try {
+      const domain: string = stepData.email.split('@')[1];
+      const authDomain: string = this.client.auth.get('domain').toString();
+      const position: number = stepData.position;
+
+      if (domain !== authDomain) {
+        return this.error('Can\'t check inbox for %s: email domain doesn\'t match %s', [
+          stepData.email,
+          authDomain,
+        ]);
+      }
+
+      const inbox: Inbox = await this.client.getInbox(stepData.email);
+
+      if (!inbox || inbox === null) {
+        return this.error('Cannot fetch inbox for: %s', [
+          stepData.email,
+        ]);
+      }
+
+      if (inbox['message']) {
+        return this.error(inbox['message']);
+      }
+
+      if (!inbox.items[position - 1]) {
+        return this.error('Cannot fetch email in position: %s', [
+          position,
+        ]);
+      }
+
+      const storageUrl: string = inbox.items.reverse()[position - 1].storage.url;
+      const email: Record<string, any> = await this.client.getEmailByStorageUrl(storageUrl);
+
+      if (email === null || !email) {
+        return this.error('Cannot fetch email in position: %s', [
+          position,
+        ]);
+      }
+
+      const htmlBody = email['body-html'];
+      const plain = email['body-plain'];
+
+      const parser = new DomParser();
+      const dom = parser.parseFromString(htmlBody);
+      const urls = dom.getElementsByTagName('a')
+                      .map(f => f.getAttribute('href'))
+                      .filter(f => f.includes('http'));
+
+      const result = await this.client.evaluateUrls(urls);
+      console.log(result.length);
+
+      return this.fail('XD');
+    } catch (e) {
+      return this.error('There was an error retrieving email messages: %s', [e.toString()]);
+    }
+  }
+}
+
+export { EmailLinksValidationStep as Step };

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -73,12 +73,14 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
                       .map(f => f.getAttribute('href'))
                       .filter(f => f.includes('http'));
 
-      const result = await this.client.evaluateUrls(urls);
-      console.log(result.length);
+      await this.client.evaluateUrls(urls);
 
-      return this.fail('XD');
+      return this.pass('No broken links were found for email %s in position %s', [
+        stepData.email,
+        position,
+      ]);
     } catch (e) {
-      return this.error('There was an error retrieving email messages: %s', [e.toString()]);
+      return this.error('Broken links found: %s', [e.toString()]);
     }
   }
 }

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -73,14 +73,24 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
                       .map(f => f.getAttribute('href'))
                       .filter(f => f.includes('http'));
 
-      await this.client.evaluateUrls(urls);
+      const brokenUrls = await this.client.evaluateUrls(urls);
+
+      if (brokenUrls.length > 0) {
+        return this.fail('Broken links found in the email. URLs include: %s', [
+          brokenUrls.join(', '),
+        ]);
+      }
 
       return this.pass('No broken links were found for email %s in position %s', [
         stepData.email,
         position,
       ]);
     } catch (e) {
-      return this.error('Broken links found: %s', [e.toString()]);
+      return this.error('There was a problem checking links in email number %d for email %s: %s', [
+        stepData.position,
+        stepData.email,
+        e.toString(),
+      ]);
     }
   }
 }

--- a/test/scenarios/broken-email-links.yml
+++ b/test/scenarios/broken-email-links.yml
@@ -2,6 +2,5 @@ scenario: Email has broken links
 description: Check if an email has broken links
 
 steps:
-- step: the 4th mailgun email for 22b4f482-34c2-4c5c-bf77-afc6d3ee19e3@thisisjust.atomatest.com should not contain broken links
-- step: the 3rd mailgun email for 22b4f482-34c2-4c5c-bf77-afc6d3ee19e3@thisisjust.atomatest.com should not contain broken links
+- step: the 1st mailgun email for 12b4f482-34c2-4c5c-bf77-afc6d3ee19e3@thisisjust.atomatest.com should not contain broken links
 

--- a/test/scenarios/broken-email-links.yml
+++ b/test/scenarios/broken-email-links.yml
@@ -1,0 +1,6 @@
+scenario: Email has broken links
+description: Check if an email has broken links
+
+steps:
+- step: the 3rd mailgun email for 22b4f482-34c2-4c5c-bf77-afc6d3ee19e3@thisisjust.atomatest.com should not contain broken links
+

--- a/test/scenarios/broken-email-links.yml
+++ b/test/scenarios/broken-email-links.yml
@@ -2,5 +2,6 @@ scenario: Email has broken links
 description: Check if an email has broken links
 
 steps:
+- step: the 4th mailgun email for 22b4f482-34c2-4c5c-bf77-afc6d3ee19e3@thisisjust.atomatest.com should not contain broken links
 - step: the 3rd mailgun email for 22b4f482-34c2-4c5c-bf77-afc6d3ee19e3@thisisjust.atomatest.com should not contain broken links
 


### PR DESCRIPTION
# Notes

1. Currently uses `Promise.all` which `fails fast` when at least one link is invalid
2. Current only checks the `body-html` of the email. Gets all the `<a>` elements and checks if the `href` are not broken using `request-promise` package
3.  Above can be tested using the scenario file `test\scenarios\broken-email-links.yml`. The first step invocation succeeds and the second step fails.

# To Do
1. There are no way yet to expose the urls that failed usign `Promise.all`
2. The `body-plain` is not yet considered for parsing `urls`

Addresses #5 