### PR TITLE
Exposed Status Code (If any) and Type (Plain or HTML) for broken url result

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "typescript": "^3.5.1"
   },
   "dependencies": {
-    "bluebird": "^3.7.1",
     "dom-parser": "^0.1.6",
     "get-urls": "^9.2.0",
     "google-protobuf": "^3.8.0",

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -5,8 +5,6 @@ import { Field } from '../core/base-step';
 import { FieldDefinition } from '../proto/cog_pb';
 import { Inbox, Email } from '../models';
 
-import { Promise as Bluebird } from 'bluebird';
-
 export class ClientWrapper {
   public static expectedAuthFields: Field[] = [{
     field: 'apiKey',
@@ -96,18 +94,18 @@ export class ClientWrapper {
   public async evaluateUrls(urls: string[]) {
     const brokenUrls = [];
 
-    return new Promise((resolve) => {
-      Bluebird.each(urls, (url) => {
-        return this.request.get(url).then((res) => {
-        }).catch(() => {
-          brokenUrls.push(url);
+    await Promise.all(urls.map((url) => {
+      return new Promise((resolve) => {
+        this.request.get(url).then(resolve).catch((err) => {
+          brokenUrls.push({
+            url,
+            message: err.statusCode ? `Status code: ${err.statusCode}` : 'No response received',
+          });
+          resolve();
         });
-      }).then(() => {
-        resolve(brokenUrls);
-      }).catch(() => {
-        resolve(brokenUrls);
       });
+    }));
 
-    });
+    return Promise.resolve(brokenUrls);
   }
 }

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -98,7 +98,7 @@ export class ClientWrapper {
       return new Promise((resolve) => {
         this.request.get(url.url).then(resolve).catch((err) => {
           brokenUrls.push({
-            url: url.url,
+            url: err.request ? err.request.uri.href : url.url,
             message: err.statusCode ? `Status code: ${err.statusCode}` : 'No response received',
             type: url.type,
           });

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -91,15 +91,16 @@ export class ClientWrapper {
     return result;
   }
 
-  public async evaluateUrls(urls: string[]) {
+  public async evaluateUrls(urls) {
     const brokenUrls = [];
 
     await Promise.all(urls.map((url) => {
       return new Promise((resolve) => {
-        this.request.get(url).then(resolve).catch((err) => {
+        this.request.get(url.url).then(resolve).catch((err) => {
           brokenUrls.push({
-            url,
+            url: url.url,
             message: err.statusCode ? `Status code: ${err.statusCode}` : 'No response received',
+            type: url.type,
           });
           resolve();
         });

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -71,9 +71,10 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
       const dom = parser.parseFromString(htmlBody);
 
       const htmlUrls = dom.getElementsByTagName('a')
-                      .map(f => f.getAttribute('href'))
-                      .filter(f => f.includes('http'));
-      const plainUrls = Array.from(GetUrls(plain).values());
+                      .map((f) => { return { url: f.getAttribute('href'), type: 'HTML' }; })
+                      .filter(f => f.url.includes('http'));
+
+      const plainUrls = Array.from(GetUrls(plain).values()).map((f) => { return { url: f, type: 'Plain' }; });
 
       const urls = new Set(htmlUrls.concat(plainUrls));
 
@@ -82,7 +83,7 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
 
       if (response.length > 0) {
         return this.fail('Broken links found in the email. URLs include: %s', [
-          response.map(f => `${f.url} (${f.message})`).join(', '),
+          response.map(f => `${f.url} (${f.message}) (Type: ${f.type})`).join(', '),
         ]);
       }
 
@@ -104,7 +105,7 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
       return;
     }
 
-    return urls.filter(f => !f.includes('%3E'));
+    return urls.filter(f => !f.url.includes('%3E'));
   }
 }
 

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -77,12 +77,12 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
 
       const urls = new Set(htmlUrls.concat(plainUrls));
 
-      const brokenUrls = await this.client.evaluateUrls(
+      const response = await this.client.evaluateUrls(
         this.sanitizeUrl(Array.from(urls.values())));
 
-      if (brokenUrls.length > 0) {
+      if (response.length > 0) {
         return this.fail('Broken links found in the email. URLs include: %s', [
-          brokenUrls.join(', '),
+          response.map(f => `${f.url} (${f.message})`).join(', '),
         ]);
       }
 

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -4,6 +4,7 @@ import { Inbox } from '../models';
 
 import * as DomParser from 'dom-parser';
 import * as GetUrls from 'get-urls';
+import * as os from 'os';
 
 /*tslint:disable:no-else-after-return*/
 export class EmailLinksValidationStep extends BaseStep implements StepInterface {
@@ -82,8 +83,14 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
         this.sanitizeUrl(Array.from(urls.values())));
 
       if (response.length > 0) {
-        return this.fail('Broken links found in the email. URLs include: %s', [
-          response.map(f => `${f.url} (${f.message}) (Type: ${f.type})`).join(', '),
+        const plain = response.filter(f => f.type === 'Plain');
+        const html = response.filter(f => f.type === 'HTML');
+        return this.fail('Broken links found in the email. URLs include: %s %s %s %s %s', [
+          os.EOL,
+          `Plain: ${os.EOL}`,
+          plain.length > 0 ? plain.map(f => `${f.url} (${f.message})`).join(`${os.EOL}`) : `No URLs found in Plain Body ${os.EOL}`,
+          `HTML: ${os.EOL}`,
+          html.length > 0 ? html.map(f => `${f.url} (${f.message})`).join(`${os.EOL}`) : `No URLS found in HTML Body ${os.EOL}`,
         ]);
       }
 

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -6,6 +6,8 @@ import * as DomParser from 'dom-parser';
 import * as GetUrls from 'get-urls';
 import * as os from 'os';
 
+const nl = os.EOL;
+
 /*tslint:disable:no-else-after-return*/
 export class EmailLinksValidationStep extends BaseStep implements StepInterface {
 
@@ -85,12 +87,12 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
       if (response.length > 0) {
         const plain = response.filter(f => f.type === 'Plain');
         const html = response.filter(f => f.type === 'HTML');
-        return this.fail('Broken links found in the email. URLs include: %s %s %s %s %s', [
-          os.EOL,
-          `Plain: ${os.EOL}`,
-          plain.length > 0 ? plain.map(f => `${f.url} (${f.message})`).join(`${os.EOL}`) : `No URLs found in Plain Body ${os.EOL}`,
-          `HTML: ${os.EOL}`,
-          html.length > 0 ? html.map(f => `${f.url} (${f.message})`).join(`${os.EOL}`) : `No URLS found in HTML Body ${os.EOL}`,
+        return this.fail('Broken links found in the email. URLs include: %s%s%s%s%s', [
+          `${nl}`,
+          `${nl}Plain: ${nl}`,
+          plain.length > 0 ? plain.map(f => `${f.url} (${f.message})`.trim()).join(`${nl}`) : `No URLs found in Plain Body${nl}`,
+          `${nl}${nl}HTML: ${nl}`,
+          html.length > 0 ? html.map(f => `${f.url} (${f.message})`.trim()).join(`${nl}`) : `No URLS found in HTML Body${nl}`,
         ]);
       }
 

--- a/test/scenarios/broken-email-links.crank.yml
+++ b/test/scenarios/broken-email-links.crank.yml
@@ -2,4 +2,4 @@ scenario: Email has broken links
 description: Check if an email has broken links
 
 steps:
-- step: the 1st mailgun email for 12b4f482-34c2-4c5c-bf77-afc6d3ee19e3@thisisjust.atomatest.com should not contain broken links
+- step: the 1st mailgun email for ee4a0492-2ee8-42f5-8a38-c41266f3db65@thisisjust.atomatest.com should not contain broken links


### PR DESCRIPTION
Continuation of feature #5 

If any error status code is present, it is returned along with the broken url. Otherwise, `No response received`.

The url source is also indicated as `Plain` or `HTML`