### PR TITLE
Handled emails with only plain text to be parsed and checked correctly

### DIFF
--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -71,7 +71,7 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
         ]);
       }
 
-      const htmlBody: string = email['body-html'];
+      const htmlBody: string = email['body-html'] || '';
       const plain: string = email['body-plain'];
 
       const parser = new DomParser();

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -72,7 +72,7 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
       }
 
       const htmlBody: string = email['body-html'] || '';
-      const plain: string = email['body-plain'];
+      const plain: string = email['body-plain'] || '';
 
       const parser = new DomParser();
       const dom = parser.parseFromString(htmlBody);


### PR DESCRIPTION
For #11 
* Defaulted both html and plain text bodies to `empty string`. The bug is caused by the external plugins used to extract `urls` from `strings`. They don't explicitly handle undefined values.