### PR TITLE
For body-plain validations, replaced all line breaks with whitespace

### DIFF
--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -104,6 +104,11 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
         Buffer.from(rawMessage).toString('base64'),
       );
 
+      if (field === 'body-plain') {
+        //// Remove all new lines and replace with whitespace
+        email[field] = email[field].replace(/(?:\r\n|\r|\n)/g, ' ');
+      }
+
       if (this.executeComparison(expectation, email[field], operator)) {
         return this.pass(
           'Check on email %s passed: %s %s "%s"',


### PR DESCRIPTION
 - Fixed a scenario wherein the `body-plain` value of an email cannot be validated due to invisible line break characters. Replaced all line breaks with whitespaces.
 