### PR TITLE
Data Ordering Fix

### DIFF
--- a/src/steps/email-count-equals.ts
+++ b/src/steps/email-count-equals.ts
@@ -102,6 +102,8 @@ export class EmailCountEqualsStep extends BaseStep implements StepInterface {
 
   createRecords(emails: Record<string, any>[]) {
     const records = [];
+    // tslint:disable-next-line:no-parameter-reassignment
+    emails = emails.reverse();
     emails.forEach((email, i) => {
       records.push({
         '#': i + 1,

--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -146,6 +146,8 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
 
   createRecords(emails: Record<string, any>[]) {
     const records = [];
+    // tslint:disable-next-line:no-parameter-reassignment
+    emails = emails.reverse();
     emails.forEach((email, i) => {
       records.push({
         '#': i + 1,

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -133,8 +133,6 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
 
   createMessageRecords(emails: Record<string, any>[]) {
     const records = [];
-    // tslint:disable-next-line:no-parameter-reassignment
-    emails = emails.reverse();
     emails.forEach((email, i) => {
       records.push({
         '#': i + 1,

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -133,6 +133,8 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
 
   createMessageRecords(emails: Record<string, any>[]) {
     const records = [];
+    // tslint:disable-next-line:no-parameter-reassignment
+    emails = emails.reverse();
     emails.forEach((email, i) => {
       records.push({
         '#': i + 1,


### PR DESCRIPTION
Fixed an issue where the displayed records appear in reverse
 - Applied similar behavior to that of the validation where the inbox items are reversed to get the right message in the expected position
 - Data displayed are also now in reverse so that the `#` column matches to the passed `position` for easier visualization

