### PR TITLE
Fixed a bug where the email objects get reversed before the validatio…

### DIFF
--- a/src/steps/email-count-equals.ts
+++ b/src/steps/email-count-equals.ts
@@ -102,9 +102,8 @@ export class EmailCountEqualsStep extends BaseStep implements StepInterface {
 
   createRecords(emails: Record<string, any>[]) {
     const records = [];
-    // tslint:disable-next-line:no-parameter-reassignment
-    emails = emails.reverse();
-    emails.forEach((email, i) => {
+    const data = [...emails.reverse()];
+    data.forEach((email, i) => {
       records.push({
         '#': i + 1,
         Subject: email.message.headers.subject,

--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -146,9 +146,8 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
 
   createRecords(emails: Record<string, any>[]) {
     const records = [];
-    // tslint:disable-next-line:no-parameter-reassignment
-    emails = emails.reverse();
-    emails.forEach((email, i) => {
+    const data = [...emails.reverse()];
+    data.forEach((email, i) => {
       records.push({
         '#': i + 1,
         Subject: email.message.headers.subject,


### PR DESCRIPTION
…n and causes wrong message to be validated

 - Fixed a critical bug where the ordering is changed prior validation causing the wrong message (in expected position) to be validated
 - Fixed by `copying` array to a new reference using `...` operator instead of reversing, and self-assigning it