### PR TITLE
Fix a bug for structured data ordering.. Again

### DIFF
--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -71,8 +71,12 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
         ]);
       }
 
-      if (inbox.items.length > 1) {
+      //// Ensure proper ordering
+      if (inbox.items) {
         inbox.items.reverse();
+      }
+
+      if (inbox.items.length > 1) {
         tableRecord = this.createRecords(inbox.items);
       }
 

--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -72,6 +72,7 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
       }
 
       if (inbox.items.length > 1) {
+        inbox.items.reverse();
         tableRecord = this.createRecords(inbox.items);
       }
 
@@ -83,7 +84,7 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
         );
       }
 
-      const storageUrl: string = inbox.items.reverse()[position - 1].storage.url;
+      const storageUrl: string = inbox.items[position - 1].storage.url;
       const email: Email = await this.client.getEmailByStorageUrl(storageUrl);
 
       //// An unexpected error occurred
@@ -146,8 +147,7 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
 
   createRecords(emails: Record<string, any>[]) {
     const records = [];
-    const data = [...emails.reverse()];
-    data.forEach((email, i) => {
+    emails.forEach((email, i) => {
       records.push({
         '#': i + 1,
         Subject: email.message.headers.subject,


### PR DESCRIPTION
With further testing, it appears that the data gets reversed twice which eventually lead to the original problem.

Ensured that there would only be 1 `reverse()` call for the emails to get the proper order.