### PR TITLE
Explicitly sorted found Email Links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2010,15 +2010,6 @@
         "pump": "^3.0.0"
       }
     },
-    "get-urls": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-9.2.0.tgz",
-      "integrity": "sha512-ErGHKhzGIrtobqmNNxjy7yxe4cEmAp9SMerzmFpldn0CkEr2EC+SvIiyef038JDjl2LVng7MMw8YunUKM7k3ww==",
-      "requires": {
-        "normalize-url": "^4.3.0",
-        "url-regex": "^5.0.0"
-      }
-    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -4442,9 +4433,9 @@
       }
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-5.0.0.tgz",
+      "integrity": "sha512-bAEm2fx8Dq/a35Z6PIRkkBBJvR56BbEJvhpNtvCZ4W9FyORSna77fn+xtYFjqk5JpBS+fMnAOG/wFgkQBmB7hw=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -5656,9 +5647,9 @@
       "dev": true
     },
     "tlds": {
-      "version": "1.203.1",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.203.1.tgz",
-      "integrity": "sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw=="
+      "version": "1.207.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.207.0.tgz",
+      "integrity": "sha512-k7d7Q1LqjtAvhtEOs3yN14EabsNO8ZCoY6RESSJDB9lst3bTx3as/m1UuAeCKzYxiyhR1qq72ZPhpSf+qlqiwg=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,13 +59,14 @@
   },
   "dependencies": {
     "@run-crank/utilities": "^0.1.6",
-    "get-urls": "^9.2.0",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.21.1",
     "https": "^1.0.0",
+    "normalize-url": "^5.0.0",
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
     "ts-node": "^8.3.0",
+    "url-regex": "^5.0.0",
     "xmldom": "^0.3.0"
   }
 }

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -119,6 +119,7 @@ export class ClientWrapper {
               type: url.type,
               statusCode: '200',
               finalUrl: response.request.uri.href,
+              order: url.order,
             });
             resolve(response);
           }).catch((err) => {
@@ -129,6 +130,7 @@ export class ClientWrapper {
               statusCode: err.statusCode ? err.statusCode : 'No response received',
               finalUrl: err.response && err.response.request
                       ? err.response.request.uri.href : url.url,
+              order: url.order,
             });
             resolve();
           });

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -118,6 +118,7 @@ export class ClientWrapper {
               message: 'Status code: 200',
               type: url.type,
               statusCode: '200',
+              finalUrl: response.request.uri.href,
             });
             resolve(response);
           }).catch((err) => {
@@ -126,6 +127,8 @@ export class ClientWrapper {
               message: err.statusCode ? `Status code: ${err.statusCode}` : 'No response received',
               type: url.type,
               statusCode: err.statusCode ? err.statusCode : 'No response received',
+              finalUrl: err.response && err.response.request
+                      ? err.response.request.uri.href : url.url,
             });
             resolve();
           });

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -118,7 +118,7 @@ export class ClientWrapper {
               message: 'Status code: 200',
               type: url.type,
               statusCode: '200',
-              finalUrl: response.request.uri.href,
+              finalUrl: response.request && response.request ? response.request.uri.href : url.url,
               order: url.order,
             });
             resolve(response);

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -118,7 +118,7 @@ export class ClientWrapper {
               message: 'Status code: 200',
               type: url.type,
               statusCode: '200',
-              finalUrl: response.request && response.request ? response.request.uri.href : url.url,
+              finalUrl: response.request ? response.request.uri.href : url.url,
               order: url.order,
             });
             resolve(response);

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -157,7 +157,8 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
       );
 
       const brokenUrls = response.brokenUrls;
-      const allUrls = response.brokenUrls.concat(response.workingUrls);
+      const allUrls = response.brokenUrls.concat(response.workingUrls)
+        .sort((a, b) => a.url.localeCompare(b.url));
       const linkRecords = this.createLinkRecords(allUrls);
 
       if (brokenUrls.length > 0) {

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -147,11 +147,14 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
         href = '';
       }
 
-      const plainUrls = Array.from(GetUrls(plain).values()).map((f) => { return { url: f, type: 'Plain' }; });
+      htmlUrls.forEach((value, i) => value.order = i + 1);
+
+      const plainUrls: any[] = Array.from(GetUrls(plain).values())
+        .map((f) => { return { url: f, type: 'Plain' }; });
+      plainUrls.forEach((value, i) => value.order = i + 1);
 
       const urls = new Set(htmlUrls.concat(plainUrls));
       const sanitizedUrls = this.sanitizeUrl(Array.from(urls.values()));
-      sanitizedUrls.forEach((value, i) => value.order = i + 1);
 
       const response = await this.client.evaluateUrls(
         sanitizedUrls,
@@ -208,16 +211,25 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
   }
 
   createLinkRecords(urls: Record<string, any>[]) {
-    const records = urls.map((url) => {
+    const asRecord = (url) => {
       return {
         Type: url.type,
         Url: url.url,
         StatusCode: url.statusCode,
         FinalUrl: url.finalUrl,
       };
-    });
+    };
+    const html = urls.filter(url => url.type === 'HTML').map(asRecord);
+    const plain = urls.filter(url => url.type === 'Plain').map(asRecord);
+    const records = html.concat(plain);
 
-    const headers = { Type: 'Type', Url: 'URL', StatusCode: 'StatusCode', FinalUrl: 'FinalUrl' };
+    const headers = {
+      Type: 'Type',
+      Url: 'URL',
+      StatusCode:
+      'StatusCode',
+      FinalUrl: 'FinalUrl',
+    };
     return this.table('links', 'Found Links', headers, records);
   }
 }

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -151,6 +151,7 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
 
       const urls = new Set(htmlUrls.concat(plainUrls));
       const sanitizedUrls = this.sanitizeUrl(Array.from(urls.values()));
+      sanitizedUrls.forEach((value, i) => value.order = i + 1);
 
       const response = await this.client.evaluateUrls(
         sanitizedUrls,
@@ -158,7 +159,7 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
 
       const brokenUrls = response.brokenUrls;
       const allUrls = response.brokenUrls.concat(response.workingUrls)
-        .sort((a, b) => a.url.localeCompare(b.url));
+        .sort((a, b) => a.order - b.order);
       const linkRecords = this.createLinkRecords(allUrls);
 
       if (brokenUrls.length > 0) {
@@ -178,7 +179,7 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
     }
   }
 
-  private sanitizeUrl(urls): string[] {
+  private sanitizeUrl(urls): any[] {
     if (!urls) {
       return;
     }

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -2,8 +2,8 @@ import { BaseStep, Field, StepInterface, ExpectedRecord } from '../core/base-ste
 import { FieldDefinition, Step, StepDefinition, StepRecord, RecordDefinition } from '../proto/cog_pb';
 import { Inbox } from '../models';
 import { DOMParser } from 'xmldom';
-
-import * as GetUrls from 'get-urls';
+import * as urlRegex from 'url-regex';
+import * as normalizeUrl from 'normalize-url';
 
 /*tslint:disable:no-else-after-return*/
 export class EmailLinksValidationStep extends BaseStep implements StepInterface {
@@ -121,51 +121,25 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
         ]);
       }
 
+      // Prepare HTML and Plain Text URLs
       const htmlBody: string = email['body-html'] || '';
-      const plain: string = email['body-plain'] || '';
+      const plainTextBody: string = email['body-plain'] || '';
+      const htmlUrls = this.extractUrlsFromHtmlBody(htmlBody);
+      const plainUrls = this.extractUrlsFromPlainTextBody(plainTextBody);
 
-      const dom = new DOMParser({
-        errorHandler: {
-          warning: () => {},
-          error: () => {},
-          fatalError: () => {},
-        },
-      }).parseFromString(htmlBody);
-
-      const anchors = dom.getElementsByTagName('a');
-      const htmlUrls = [];
-      let href: string;
-      // tslint:disable-next-line:no-increment-decrement
-      for (let i = 0; i < anchors.length; i++) {
-        href = anchors.item(i).getAttribute('href');
-        if (href && href.includes('http')) {
-          htmlUrls.push({
-            url: href,
-            type: 'HTML',
-          });
-        }
-        href = '';
-      }
-
-      htmlUrls.forEach((value, i) => value.order = i + 1);
-
-      const plainUrls: any[] = Array.from(GetUrls(plain).values())
-        .map((f) => { return { url: f, type: 'Plain' }; });
-      plainUrls.forEach((value, i) => value.order = i + 1);
-
+      // Use `Set` to ensure uniqueness and each unique URL gets evaluated only once
       const urls = new Set(htmlUrls.concat(plainUrls));
-      const sanitizedUrls = this.sanitizeUrl(Array.from(urls.values()));
+      const sanitizedUrls = this.sanitizeUrls(Array.from(urls.values()));
 
-      const response = await this.client.evaluateUrls(
-        sanitizedUrls,
-      );
+      // Evaluate every URLs to check which are broken
+      const response = await this.client.evaluateUrls(sanitizedUrls);
 
-      const brokenUrls = response.brokenUrls;
+      // Join all URLs and order them as found initially from the email.
       const allUrls = response.brokenUrls.concat(response.workingUrls)
         .sort((a, b) => a.order - b.order);
       const linkRecords = this.createLinkRecords(allUrls);
 
-      if (brokenUrls.length > 0) {
+      if (response.brokenUrls.length > 0) {
         return this.fail('Broken links were found in the email', [], [linkRecords, messageRecords]);
       }
 
@@ -182,12 +156,65 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
     }
   }
 
-  private sanitizeUrl(urls): any[] {
+  private sanitizeUrls(urls): any[] {
     if (!urls) {
       return;
     }
 
-    return urls.filter(f => !f.url.includes('%3E'));
+    return urls.map((url) => {
+      url.url = url.url.replace('%3E', '');
+      return url;
+    });
+  }
+
+  private extractUrlsFromHtmlBody(htmlBody: string): any[] {
+    const dom = new DOMParser({
+      errorHandler: {
+        warning: () => {},
+        error: () => {},
+        fatalError: () => {},
+      },
+    }).parseFromString(htmlBody);
+
+    const anchors = dom.getElementsByTagName('a');
+    const htmlUrls = [];
+    let href: string;
+    // tslint:disable-next-line:no-increment-decrement
+    for (let i = 0; i < anchors.length; i++) {
+      href = anchors.item(i).getAttribute('href');
+      if (href && href.includes('http')) {
+        htmlUrls.push({
+          url: href,
+          type: 'HTML',
+        });
+      }
+      href = '';
+    }
+
+    // Ensure ordering as found from the inbox
+    htmlUrls.forEach((value, i) => value.order = i + 1);
+
+    return htmlUrls;
+  }
+
+  private extractUrlsFromPlainTextBody(plainTextBody: string): any[] {
+    // Use a `Set` to ensure uniqueness
+    const unique = new Set();
+
+    const normalizeOptions: normalizeUrl.Options = {
+      stripWWW: false,
+      sortQueryParameters: false,
+      removeTrailingSlash: false,
+    };
+
+    const urls: string[] = plainTextBody.match(urlRegex()) || [];
+    urls.map(url => unique.add(normalizeUrl(url.trim().replace(/\.+$/, ''), normalizeOptions)));
+
+    const result: any[] = Array.from(unique.values())
+      .map((f) => { return { url: f, type: 'Plain' }; });
+    // Ensure ordering as found in the email
+    result.forEach((value, i) => value.order = i + 1);
+    return result;
   }
 
   createMessageRecords(emails: Record<string, any>[]) {

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -213,10 +213,11 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
         Type: url.type,
         Url: url.url,
         StatusCode: url.statusCode,
+        FinalUrl: url.finalUrl,
       };
     });
 
-    const headers = { Type: 'Type', Url: 'URL', StatusCode: 'StatusCode' };
+    const headers = { Type: 'Type', Url: 'URL', StatusCode: 'StatusCode', FinalUrl: 'FinalUrl' };
     return this.table('links', 'Found Links', headers, records);
   }
 }


### PR DESCRIPTION
For issue #25  and other found issues
## Main Issue
1. Email Links are now sorted as found/parsed from the Email
2. HTML urls are displayed first before Plain
3. Added `finalUrl` to `urls` returned as `Structured Data`

## Other Issues fixed
1. Fixed from not including `www` sub-domains in the URLs
2. Fixed an instance where valid urls are being evaluated as broken