### PR TITLE
changed url extraction to remove punctuation from end of links

### DIFF
--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -208,7 +208,8 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
     };
 
     const urls: string[] = plainTextBody.match(urlRegex()) || [];
-    urls.map(url => unique.add(normalizeUrl(url.trim().replace(/[,\.\]["<>{}`]*$/, ''), normalizeOptions)));
+    urls.map(url => unique.add(normalizeUrl(url.trim().replace(/[,\.\]["<>{}`]*$/, ''), 
+    normalizeOptions)));
 
     const result: any[] = Array.from(unique.values())
       .map((f) => { return { url: f, type: 'Plain' }; });

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -208,7 +208,7 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
     };
 
     const urls: string[] = plainTextBody.match(urlRegex()) || [];
-    urls.map(url => unique.add(normalizeUrl(url.trim().replace(/\.+$/, ''), normalizeOptions)));
+    urls.map(url => unique.add(normalizeUrl(url.trim().replace(/[,\.\]["<>{}`]*$/, ''), normalizeOptions)));
 
     const result: any[] = Array.from(unique.values())
       .map((f) => { return { url: f, type: 'Plain' }; });

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -208,8 +208,8 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
     };
 
     const urls: string[] = plainTextBody.match(urlRegex()) || [];
-    urls.map(url => unique.add(normalizeUrl(url.trim().replace(/[,\.\]["<>{}`]*$/, ''), 
-    normalizeOptions)));
+    urls.map(url =>
+      unique.add(normalizeUrl(url.trim().replace(/[,\.\]["<>{}`]*$/, ''), normalizeOptions)));
 
     const result: any[] = Array.from(unique.values())
       .map((f) => { return { url: f, type: 'Plain' }; });


### PR DESCRIPTION
Currently, our plain text link extraction will remove periods from the end of links in emails.  This pull request will also remove commas and some other punctuation like `<>[]{}`` from the end of the links that are scraped from plain text.  This should fix Bug 3445.  The failed scenario can be found [here](https://app.stackmoxie.com/home/9c957a02-674c-4e91-addf-b25bddeb01a4/scenarios/3598/runs/705783)