### PR TITLE
Enable checkUrls method to set cookies

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -195,7 +195,7 @@ export class ClientWrapper {
     const checkUrls = async (urls) => {
       await Promise.all(urls.map((url) => {
         return new Promise((resolve) => {
-          this.request.get(url.url)
+          this.request.get({ url: url.url, jar: true })
             .then((response) => {
               // The following code will check for redirect urls from marketo forms
               if (response.includes('var redirecturl') && response.includes('window.self.location = redirecturl') && response.includes('function redirect() {')) {


### PR DESCRIPTION
Certain links were sending request.get method to infinite redirects. This was causing some links to fail, when they were actually working. This fix will enable the request.get method to set cookies, which stops the infinite redirects from certain websites. 