### PR TITLE
Handle Marketo Javascript Redirects

### DIFF
--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -220,7 +220,7 @@ export class ClientWrapper {
               });
               resolve(response);
             }).catch((err) => {
-              // Handle unconventional redirects
+              // Handle unconventional redirects (Most 302 redirects are already handled without throwing an error)
               if (err.statusCode && err.statusCode === 302) {
                 // Check for javascript redirects
                 if (err.response && err.response.body && err.response.body.includes('window.self.location = ')) {
@@ -236,6 +236,17 @@ export class ClientWrapper {
                         type: 'HTML',
                       });
                     }
+                  } else {
+                    brokenUrls.push({
+                      url: err.response && err.response.request
+                        ? err.response.request.uri.href : url.url,
+                      message: err.statusCode ? `Status code: ${err.statusCode}` : 'No response received',
+                      type: url.type,
+                      statusCode: err.statusCode ? err.statusCode : 'No response received',
+                      finalUrl: err.response && err.response.request
+                        ? err.response.request.uri.href : url.url,
+                      order: url.order,
+                    });
                   }
                 } else if (err.response && err.response.body && err.response.body.includes('404 Not Found') && err.response.body.includes('The redirect url is empty')) {
                   // Handle case where a marketo redirects to a 404

--- a/src/client/client-wrapper.ts
+++ b/src/client/client-wrapper.ts
@@ -220,7 +220,49 @@ export class ClientWrapper {
               });
               resolve(response);
             }).catch((err) => {
-              if (err.statusCode && err.statusCode === 999) {
+              // Handle unconventional redirects
+              if (err.statusCode && err.statusCode === 302) {
+                // Check for javascript redirects
+                if (err.response && err.response.body && err.response.body.includes('window.self.location = ')) {
+                  // This code is for marketo scripts
+                  if (err.response.body.includes('var redirecturl = ') && err.response.body.includes('window.self.location = redirecturl') && err.response.body.includes('function redirect() {')) {
+                    // This code will handle a marketo script response
+                    const re = /(?<=var redirecturl = ').*?(?=')/;
+                    const redirectLink = re.exec(err.response.body)[0];
+                    // Don't check mailto: links
+                    if (!redirectLink.includes('mailto:')) {
+                      redirectUrls.push({
+                        url: redirectLink,
+                        type: 'HTML',
+                      });
+                    }
+                  }
+                } else if (err.response && err.response.body && err.response.body.includes('404 Not Found') && err.response.body.includes('The redirect url is empty')) {
+                  // Handle case where a marketo redirects to a 404
+                  brokenUrls.push({
+                    url: err.response && err.response.request
+                      ? err.response.request.uri.href : url.url,
+                    message: 'The redirect url is empty',
+                    type: url.type,
+                    statusCode: '404',
+                    finalUrl: err.response && err.response.request
+                      ? err.response.request.uri.href : url.url,
+                    order: url.order,
+                  });
+                } else {
+                  // If we are unable to extract the link from javascript, then fail the url
+                  brokenUrls.push({
+                    url: err.response && err.response.request
+                      ? err.response.request.uri.href : url.url,
+                    message: err.statusCode ? `Status code: ${err.statusCode}` : 'No response received',
+                    type: url.type,
+                    statusCode: err.statusCode ? err.statusCode : 'No response received',
+                    finalUrl: err.response && err.response.request
+                      ? err.response.request.uri.href : url.url,
+                    order: url.order,
+                  });
+                }
+              } else if (err.statusCode && err.statusCode === 999) {
                 // If this is an error code 999 (LinkedIn), then add this to the working urls
                 workingUrls.push({
                   url: err.response && err.response.request


### PR DESCRIPTION
Currently, most redirects with code 302 will be automatically followed and evaluated using the request package. However, if a page is redirected using JavaScript, then it will throw an error.

This will handle specific JavaScript redirects coming from Marketo emails. This is a client request.