### PR TITLE
Add retry logic to email validation steps

### DIFF
--- a/src/steps/email-count-equals.ts
+++ b/src/steps/email-count-equals.ts
@@ -62,10 +62,10 @@ export class EmailCountEqualsStep extends BaseStep implements StepInterface {
       let inbox: Inbox;
       let retryCount = 0;
       const maxRetries = 3;
-      
+
       while (retryCount < maxRetries) {
         inbox = await this.client.getInbox(stepData.email);
-        
+
         if (!inbox || inbox === null) {
           return this.error("There was a problem checking %s's email: no inbox found.", [
             stepData.email,
@@ -84,8 +84,8 @@ export class EmailCountEqualsStep extends BaseStep implements StepInterface {
         if (stepData.count === 0 || inbox.items.length === stepData.count || inbox.items.length > 0) {
           break; // Success or proceed with current state
         }
-        
-        retryCount++;
+
+        retryCount += 1;
         if (retryCount < maxRetries) {
           // Wait before retrying (exponential backoff: 1s, 2s, 4s)
           await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount - 1)));

--- a/src/steps/email-count-equals.ts
+++ b/src/steps/email-count-equals.ts
@@ -58,19 +58,38 @@ export class EmailCountEqualsStep extends BaseStep implements StepInterface {
         ]);
       }
 
-      const inbox: Inbox = await this.client.getInbox(stepData.email);
+      // Add retry logic for getInbox to handle transient API issues
+      let inbox: Inbox;
+      let retryCount = 0;
+      const maxRetries = 3;
+      
+      while (retryCount < maxRetries) {
+        inbox = await this.client.getInbox(stepData.email);
+        
+        if (!inbox || inbox === null) {
+          return this.error("There was a problem checking %s's email: no inbox found.", [
+            stepData.email,
+          ]);
+        }
 
-      if (!inbox || inbox === null) {
-        return this.error("There was a problem checking %s's email: no inbox found.", [
-          stepData.email,
-        ]);
-      }
+        if (inbox['message']) {
+          return this.error("There was a problem checking %s's email: %s", [
+            stepData.email,
+            inbox['message'],
+          ]);
+        }
 
-      if (inbox['message']) {
-        return this.error("There was a problem checking %s's email: %s", [
-          stepData.email,
-          inbox['message'],
-        ]);
+        // If we expect emails but got none, retry (handles transient empty responses)
+        // If we expect 0 or we got the expected count, or we got some emails, proceed
+        if (stepData.count === 0 || inbox.items.length === stepData.count || inbox.items.length > 0) {
+          break; // Success or proceed with current state
+        }
+        
+        retryCount++;
+        if (retryCount < maxRetries) {
+          // Wait before retrying (exponential backoff: 1s, 2s, 4s)
+          await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount - 1)));
+        }
       }
 
       // tslint:disable-next-line:triple-equals

--- a/src/steps/email-count-equals.ts
+++ b/src/steps/email-count-equals.ts
@@ -85,6 +85,7 @@ export class EmailCountEqualsStep extends BaseStep implements StepInterface {
           break; // Success or proceed with current state
         }
 
+        // Only retry if we expect emails but got completely empty inbox
         retryCount += 1;
         if (retryCount < maxRetries) {
           // Wait before retrying (exponential backoff: 1s, 2s, 4s)

--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -89,6 +89,12 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
           break; // Success, we have the email
         }
 
+        // Only retry if inbox is completely empty (timing issue)
+        // If inbox has items but not our position, it's likely a real error, not timing
+        if (inbox.items && inbox.items.length > 0) {
+          break; // Don't retry - inbox has emails, just not at our position
+        }
+
         retryCount += 1;
         if (retryCount < maxRetries) {
           // Wait before retrying (exponential backoff: 1s, 2s, 4s)

--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -44,7 +44,6 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
     // tslint:disable-next-line:radix
     const position = parseInt(stepData.position) || 1;
     const operator = stepData.operator;
-    let tableRecord;
     let binaryRecord;
 
     try {
@@ -63,10 +62,10 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
       let inbox: Inbox;
       let retryCount = 0;
       const maxRetries = 3;
-      
+
       while (retryCount < maxRetries) {
         inbox = await this.client.getInbox(stepData.email);
-        
+
         if (!inbox || inbox === null) {
           return this.error("There was a problem checking %s's email: no inbox found.", [
             stepData.email,
@@ -89,8 +88,8 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
         if (inbox.items && inbox.items.length > 0 && inbox.items[position - 1]) {
           break; // Success, we have the email
         }
-        
-        retryCount++;
+
+        retryCount += 1;
         if (retryCount < maxRetries) {
           // Wait before retrying (exponential backoff: 1s, 2s, 4s)
           await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount - 1)));

--- a/src/steps/email-field-validation.ts
+++ b/src/steps/email-field-validation.ts
@@ -50,6 +50,7 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
     try {
       const domain: string = stepData.email.split('@')[1];
       const authDomain: string = this.client.auth.get('domain').toString();
+      const position: number = stepData.position;
 
       if (domain !== authDomain) {
         return this.error("Couldn't check %s's email: Only addresses with the %s domain can be checked.", [
@@ -58,26 +59,45 @@ export class EmailFieldValidationStep extends BaseStep implements StepInterface 
         ]);
       }
 
-      const inbox: Inbox = await this.client.getInbox(stepData.email);
+      // Add retry logic for getInbox to handle transient API issues
+      let inbox: Inbox;
+      let retryCount = 0;
+      const maxRetries = 3;
+      
+      while (retryCount < maxRetries) {
+        inbox = await this.client.getInbox(stepData.email);
+        
+        if (!inbox || inbox === null) {
+          return this.error("There was a problem checking %s's email: no inbox found.", [
+            stepData.email,
+          ]);
+        }
 
-      if (!inbox || inbox === null) {
-        return this.error("There was a problem checking %s's email: no inbox found.", [
-          stepData.email,
-        ]);
+        if (inbox['message']) {
+          return this.error("There was a problem checking %s's email: %s", [
+            stepData.email,
+            inbox['message'],
+          ]);
+        }
+
+        // Ensure proper ordering
+        if (inbox.items) {
+          inbox.items.reverse();
+        }
+
+        // Check if we have the expected email, if not retry
+        if (inbox.items && inbox.items.length > 0 && inbox.items[position - 1]) {
+          break; // Success, we have the email
+        }
+        
+        retryCount++;
+        if (retryCount < maxRetries) {
+          // Wait before retrying (exponential backoff: 1s, 2s, 4s)
+          await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount - 1)));
+        }
       }
 
-      if (inbox['message']) {
-        return this.error("There was a problem checking %s's email: %s", [
-          stepData.email,
-          inbox['message'],
-        ]);
-      }
-
-      //// Ensure proper ordering
-      if (inbox.items) {
-        inbox.items.reverse();
-      }
-
+      let tableRecord;
       if (inbox.items.length > 1) {
         tableRecord = this.createRecords(inbox.items);
       }

--- a/src/steps/email-images-validation.ts
+++ b/src/steps/email-images-validation.ts
@@ -81,10 +81,10 @@ export class EmailImagesValidationStep extends BaseStep implements StepInterface
       let inbox: Inbox;
       let retryCount = 0;
       const maxRetries = 3;
-      
+
       while (retryCount < maxRetries) {
         inbox = await this.client.getInbox(stepData.email);
-        
+
         if (!inbox || inbox === null) {
           return this.error("There was a problem checking %s's email: no inbox found.", [
             stepData.email,
@@ -102,8 +102,8 @@ export class EmailImagesValidationStep extends BaseStep implements StepInterface
         if (inbox.items && inbox.items.length > 0 && inbox.items[position - 1]) {
           break; // Success, we have the email
         }
-        
-        retryCount++;
+
+        retryCount += 1;
         if (retryCount < maxRetries) {
           // Wait before retrying (exponential backoff: 1s, 2s, 4s)
           await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount - 1)));

--- a/src/steps/email-images-validation.ts
+++ b/src/steps/email-images-validation.ts
@@ -103,6 +103,12 @@ export class EmailImagesValidationStep extends BaseStep implements StepInterface
           break; // Success, we have the email
         }
 
+        // Only retry if inbox is completely empty (timing issue)
+        // If inbox has items but not our position, it's likely a real error, not timing
+        if (inbox.items && inbox.items.length > 0) {
+          break; // Don't retry - inbox has emails, just not at our position
+        }
+
         retryCount += 1;
         if (retryCount < maxRetries) {
           // Wait before retrying (exponential backoff: 1s, 2s, 4s)

--- a/src/steps/email-images-validation.ts
+++ b/src/steps/email-images-validation.ts
@@ -77,19 +77,37 @@ export class EmailImagesValidationStep extends BaseStep implements StepInterface
         ]);
       }
 
-      const inbox: Inbox = await this.client.getInbox(stepData.email);
+      // Add retry logic for getInbox to handle transient API issues
+      let inbox: Inbox;
+      let retryCount = 0;
+      const maxRetries = 3;
+      
+      while (retryCount < maxRetries) {
+        inbox = await this.client.getInbox(stepData.email);
+        
+        if (!inbox || inbox === null) {
+          return this.error("There was a problem checking %s's email: no inbox found.", [
+            stepData.email,
+          ]);
+        }
 
-      if (!inbox || inbox === null) {
-        return this.error("There was a problem checking %s's email: no inbox found.", [
-          stepData.email,
-        ]);
-      }
+        if (inbox['message']) {
+          return this.error("There was a problem checking %s's email: %s", [
+            stepData.email,
+            inbox['message'],
+          ]);
+        }
 
-      if (inbox['message']) {
-        return this.error("There was a problem checking %s's email: %s", [
-          stepData.email,
-          inbox['message'],
-        ]);
+        // Check if we have the expected email, if not retry
+        if (inbox.items && inbox.items.length > 0 && inbox.items[position - 1]) {
+          break; // Success, we have the email
+        }
+        
+        retryCount++;
+        if (retryCount < maxRetries) {
+          // Wait before retrying (exponential backoff: 1s, 2s, 4s)
+          await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount - 1)));
+        }
       }
 
       let messageRecords;

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -88,19 +88,37 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
         ]);
       }
 
-      const inbox: Inbox = await this.client.getInbox(stepData.email);
+      // Add retry logic for getInbox to handle transient API issues
+      let inbox: Inbox;
+      let retryCount = 0;
+      const maxRetries = 3;
+      
+      while (retryCount < maxRetries) {
+        inbox = await this.client.getInbox(stepData.email);
+        
+        if (!inbox || inbox === null) {
+          return this.error("There was a problem checking %s's email: no inbox found.", [
+            stepData.email,
+          ]);
+        }
 
-      if (!inbox || inbox === null) {
-        return this.error("There was a problem checking %s's email: no inbox found.", [
-          stepData.email,
-        ]);
-      }
+        if (inbox['message']) {
+          return this.error("There was a problem checking %s's email: %s", [
+            stepData.email,
+            inbox['message'],
+          ]);
+        }
 
-      if (inbox['message']) {
-        return this.error("There was a problem checking %s's email: %s", [
-          stepData.email,
-          inbox['message'],
-        ]);
+        // Check if we have the expected email, if not retry
+        if (inbox.items && inbox.items.length > 0 && inbox.items[position - 1]) {
+          break; // Success, we have the email
+        }
+        
+        retryCount++;
+        if (retryCount < maxRetries) {
+          // Wait before retrying (exponential backoff: 1s, 2s, 4s)
+          await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount - 1)));
+        }
       }
 
       let messageRecords;

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -114,6 +114,12 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
           break; // Success, we have the email
         }
 
+        // Only retry if inbox is completely empty (timing issue)
+        // If inbox has items but not our position, it's likely a real error, not timing
+        if (inbox.items && inbox.items.length > 0) {
+          break; // Don't retry - inbox has emails, just not at our position
+        }
+
         retryCount += 1;
         if (retryCount < maxRetries) {
           // Wait before retrying (exponential backoff: 1s, 2s, 4s)

--- a/src/steps/email-links-validation.ts
+++ b/src/steps/email-links-validation.ts
@@ -92,10 +92,10 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
       let inbox: Inbox;
       let retryCount = 0;
       const maxRetries = 3;
-      
+
       while (retryCount < maxRetries) {
         inbox = await this.client.getInbox(stepData.email);
-        
+
         if (!inbox || inbox === null) {
           return this.error("There was a problem checking %s's email: no inbox found.", [
             stepData.email,
@@ -113,8 +113,8 @@ export class EmailLinksValidationStep extends BaseStep implements StepInterface 
         if (inbox.items && inbox.items.length > 0 && inbox.items[position - 1]) {
           break; // Success, we have the email
         }
-        
-        retryCount++;
+
+        retryCount += 1;
         if (retryCount < maxRetries) {
           // Wait before retrying (exponential backoff: 1s, 2s, 4s)
           await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount - 1)));


### PR DESCRIPTION
Fixes production issue where email validation steps would inconsistently fail with "no emails found" while other steps succeeded.

Added retry logic with exponential backoff (up to 3 attempts) to handle transient Mailgun API responses in:
- email-count-equals.ts
- email-links-validation.ts  
- email-images-validation.ts
- email-field-validation.ts